### PR TITLE
Customize JWT View return usertype in payload and response.

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -7,7 +7,7 @@ from rest_framework.reverse import reverse_lazy
 
 # Create your models here.
 class Patient(models.Model):
-    user = models.OneToOneField('auth.User', on_delete=models.CASCADE)
+    user = models.OneToOneField('auth.User', related_name="patient", on_delete=models.CASCADE)
     uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     first_name = models.CharField(max_length=32, null=True, blank=True)
     last_name = models.CharField(max_length=32, null=True, blank=True)
@@ -32,7 +32,7 @@ class Patient(models.Model):
 
 
 class HealthOfficer(models.Model):
-    user = models.OneToOneField('auth.User', on_delete=models.CASCADE)
+    user = models.OneToOneField('auth.User', related_name="health_officer", on_delete=models.CASCADE)
     uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     first_name = models.CharField(max_length=32, null=True, blank=True)
     last_name = models.CharField(max_length=32, null=True, blank=True)
@@ -58,7 +58,7 @@ class HealthOfficer(models.Model):
 
 
 class Hospital(models.Model):
-    user = models.OneToOneField('auth.User', on_delete=models.CASCADE)
+    user = models.OneToOneField('auth.User', related_name="hospital", on_delete=models.CASCADE)
     uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     name = models.CharField(max_length=256)
     specialty = models.CharField(max_length=64, default='general')

--- a/api/urls.py
+++ b/api/urls.py
@@ -18,7 +18,8 @@ from .views import (
     HospitalCreateAPIView,
     HospitalListAPIView,
     HospitalRetrieveUpdateAPIView,
-    APIDocumentationView
+    APIDocumentationView,
+    CustomTokenObtainPairView
 )
 
 
@@ -100,7 +101,7 @@ urlpatterns = [
 
     path(
         'user/login/',
-        TokenObtainPairView.as_view(),
+        CustomTokenObtainPairView.as_view(),
         name='token_obtain_pair'
     ),
     

--- a/api/views.py
+++ b/api/views.py
@@ -13,12 +13,15 @@ from .custom_permissions import (
     HealthOfficerOrPatientReadOnlyOnHealthOfficerRetrieveUpdate
 )
 
+from rest_framework_simplejwt.views import TokenObtainPairView
+
 from .models import Patient, HealthOfficer, MedicalRecord, Hospital
 from .serializers import (
     PatientSerializer,
     HealthOfficerSerializer,
     MedicalRecordSerializer,
-    HospitalSerializer
+    HospitalSerializer,
+    CustomTokenObtainPairSerializer
 )
 
 
@@ -27,6 +30,10 @@ class APIDocumentationView(APIView):
     def get(self, request, format=None):
         postman_doc_link = "https://documenter.getpostman.com/view/16360417/Tzm5HHGL"
         return redirect(postman_doc_link, permanent=True)
+
+
+class CustomTokenObtainPairView(TokenObtainPairView):
+    serializer_class = CustomTokenObtainPairSerializer
 
 
 # Create your views here.


### PR DESCRIPTION
login response now contains access, refresh, and usertype fields
add related_name to models for easy lookup